### PR TITLE
Using prevState and adding key attribute

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,14 +17,14 @@ class App extends Component {
     connect((msg) => {
       console.log("New Message")
       this.setState(prevState => ({
-        chatHistory: [...this.state.chatHistory, msg]
+        chatHistory: [...prevState.chatHistory, msg]
       }))
       console.log(this.state);
     });
   }
-  
+
   send(event) {
-    if(event.keyCode === 13) {
+    if (event.keyCode === 13) {
       sendMsg(event.target.value);
       event.target.value = "";
     }

--- a/frontend/src/components/ChatHistory/ChatHistory.jsx
+++ b/frontend/src/components/ChatHistory/ChatHistory.jsx
@@ -5,7 +5,7 @@ import Message from '../Message/Message';
 class ChatHistory extends Component {
   render() {
     console.log(this.props.chatHistory);
-    const messages = this.props.chatHistory.map(msg => <Message message={msg.data} />);
+    const messages = this.props.chatHistory.map(msg => <Message key={msg.timeStamp} message={msg.data} />);
 
     return (
       <div className='ChatHistory'>


### PR DESCRIPTION
I noticed that in line 19 of `/frontend/src/App.js`, we're setting up the `prevState` argument in our updater function, but aren't making use of it on line 20.  Because we're updating state in reference to the component's previous state, we want to make sure we avoid using `this.state`, to avoid any unexpected behavior due to the asynchronous nature of `this.setState`.

In addition, to this, on line 8 of `/frontend/src/components/ChatHistory.jsx`, a key attribute isn't passed to our Message component when we map over the array.  I make use of `msg.timeStamp` for this, as it is the most unique of the properties on msg.

I also wanted to note that in part 3 of the lesson, when first setting up ChatHistory.jsx, we made use of the entry's `index` as a key attribute.  This generally isn't recommended, as the index can change over time (e.g. when a message is deleted by a moderator).  It might be worth addressing using the timeStamp at that point.